### PR TITLE
/root/openrc not required as /root/keystonerc_admin already created for ...

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/controller.pp
+++ b/puppet/modules/quickstack/manifests/neutron/controller.pp
@@ -349,12 +349,6 @@ class quickstack::neutron::controller (
     nova_config { 'DEFAULT/scheduler_driver': value => 'nova.scheduler.filter_scheduler.FilterScheduler' }
     nova_config { 'DEFAULT/libvirt_vif_type': value => 'ethernet'}
     nova_config { 'DEFAULT/libvirt_cpu_mode': value => 'none'}
-
-    class { 'openstack::auth_file':
-      admin_password          => $admin_password,
-      admin_tenant            => 'admin',
-      controller_node         => $controller_priv_host,
-    }
   }
 
   firewall { '001 neutron server (API)':


### PR DESCRIPTION
...the purpose.

Signed-off-by: salmank salmank@plumgrid.com
