### PR TITLE
Foreman picks pg_enable_metadata as string if provided through params.pp...

### DIFF
--- a/puppet/modules/quickstack/manifests/neutron/controller.pp
+++ b/puppet/modules/quickstack/manifests/neutron/controller.pp
@@ -52,7 +52,7 @@ class quickstack::neutron::controller (
   $pg_username                   = $quickstack::params::pg_username,
   $pg_password                   = $quickstack::params::pg_password,
   $pg_servertimeout              = $quickstack::params::pg_servertimeout,
-  $pg_enable_metadata_agent      = $quickstack::params::pg_enable_metadata_agent,
+  $pg_enable_metadata_agent      = false,
   $pg_fw_src                     = $quickstack::params::pg_fw_src,
   $pg_fw_dest                    = $quickstack::params::pg_fw_dest,
   $controller_priv_host          = $quickstack::params::controller_priv_host,

--- a/puppet/modules/quickstack/manifests/params.pp
+++ b/puppet/modules/quickstack/manifests/params.pp
@@ -131,7 +131,6 @@ class quickstack::params (
   $pg_username                   = 'PLUMgrid_Director_Admin',
   $pg_password                   = 'PLUMgrid_Director_Admin_Password',
   $pg_servertimeout              = '70',
-  $pg_enable_metadata_agent      = false,
   $pg_fw_src                     = undef,
   $pg_fw_dest                    = undef,
   # End PLUMgrid config


### PR DESCRIPTION
... and runs in error if override as boolean.

So it skips passing through params.pp.

Signed-off-by: salmank salmank@plumgrid.com
